### PR TITLE
Refactor codebase to align with Google's C++ Style Guide

### DIFF
--- a/src/common/2D/object2D.cpp
+++ b/src/common/2D/object2D.cpp
@@ -3,10 +3,10 @@
 namespace common {
 namespace twod {
 
-bool Object2D::containsPoint(glm::vec2 point) {
-  return (this->position.x < point.x) && (this->position.y < point.y) &&
-         ((this->position.x + (this->size.x * this->scale.x)) > point.x) &&
-         ((this->position.y + (this->size.y * this->scale.y)) > point.y);
+bool Object2D::containsPoint(glm::vec2 point) const {
+  return (position_.x < point.x) && (position_.y < point.y) &&
+         ((position_.x + (size_.x * scale_.x)) > point.x) &&
+         ((position_.y + (size_.y * scale_.y)) > point.y);
 }
 
 }  // namespace twod

--- a/src/common/2D/object2D.h
+++ b/src/common/2D/object2D.h
@@ -1,5 +1,5 @@
-#ifndef OBJECT2D_H
-#define OBJECT2D_H
+#ifndef COMMON_2D_OBJECT2D_H_
+#define COMMON_2D_OBJECT2D_H_
 
 #include "glm/vec2.hpp"
 
@@ -12,35 +12,37 @@ namespace twod {
 class Object2D {
  public:
   Object2D()
-      : position(0.0f), size(0.0f), scale(1.0f), rotation_radians(0.0f) {}
+      : position_(0.0f),
+        size_(0.0f),
+        scale_(1.0f),
+        rotation_radians_(0.0f) {}
   Object2D(glm::vec2 position, glm::vec2 size, glm::vec2 scale)
-      : position(position), size(size), scale(scale), rotation_radians(0.0f) {}
+      : position_(position),
+        size_(size),
+        scale_(scale),
+        rotation_radians_(0.0f) {}
 
-  void setPosition(glm::vec2 position) { this->position = position; }
+  void setPosition(glm::vec2 position) { position_ = position; }
+  glm::vec2 getPosition() const { return position_; }
 
-  glm::vec2 getPosition() { return this->position; }
+  void setSize(glm::vec2 size) { size_ = size; }
+  glm::vec2 getSize() const { return size_; }
 
-  void setSize(glm::vec2 size) { this->size = size; }
+  void setScale(glm::vec2 scale) { scale_ = scale; }
+  glm::vec2 getScale() const { return scale_; }
 
-  glm::vec2 getSize() { return this->size; }
+  void setRotationRadians(float radians) { rotation_radians_ = radians; }
+  float getRotationRadians() const { return rotation_radians_; }
 
-  void setScale(glm::vec2 scale) { this->scale = scale; }
-
-  glm::vec2 getScale() { return this->scale; }
-
-  void setRotationRadians(float radians) { this->rotation_radians = radians; }
-
-  float getRotationRadians() { return this->rotation_radians; }
-
-  bool containsPoint(glm::vec2 point);
+  bool containsPoint(glm::vec2 point) const;
 
  private:
-  glm::vec2 position;
-  glm::vec2 size;
-  glm::vec2 scale;
-  float rotation_radians;
+  glm::vec2 position_;
+  glm::vec2 size_;
+  glm::vec2 scale_;
+  float rotation_radians_;
 };
 }  // namespace twod
 }  // namespace common
 
-#endif  // OBJECT2D_H
+#endif  // COMMON_2D_OBJECT2D_H_

--- a/src/common/2D/renderer_manager.cpp
+++ b/src/common/2D/renderer_manager.cpp
@@ -6,19 +6,18 @@
 namespace common {
 namespace twod {
 
-using common::resources::ResourceManager;
-using common::resources::Shader;
-
 RendererManager::RendererManager(glm::mat4 projection_matrix) {
-  Shader sprite_shader = ResourceManager::LoadShaderRelative(
-      "src/common/resources/shaders/sprite.vert",
-      "src/common/resources/shaders/sprite.frag", "sprite_shader");
-  Shader text_shader = ResourceManager::LoadShaderRelative(
-      "src/common/resources/shaders/font.vert",
-      "src/common/resources/shaders/font.frag", "text_shader");
-  this->sprite_renderer =
+  common::resources::Shader sprite_shader =
+      common::resources::ResourceManager::LoadShader(
+          "src/common/resources/shaders/sprite.vert",
+          "src/common/resources/shaders/sprite.frag", "sprite_shader");
+  common::resources::Shader text_shader =
+      common::resources::ResourceManager::LoadShader(
+          "src/common/resources/shaders/font.vert",
+          "src/common/resources/shaders/font.frag", "text_shader");
+  sprite_renderer_ =
       std::make_shared<SpriteRenderer>(sprite_shader, projection_matrix);
-  this->text_renderer =
+  text_renderer_ =
       std::make_shared<TextRenderer>(text_shader, projection_matrix);
 }
 

--- a/src/common/2D/renderer_manager.h
+++ b/src/common/2D/renderer_manager.h
@@ -1,7 +1,9 @@
-#ifndef RENDERER_MANAGER_H
-#define RENDERER_MANAGER_H
+#ifndef COMMON_2D_RENDERER_MANAGER_H_
+#define COMMON_2D_RENDERER_MANAGER_H_
 
 #include <memory>
+
+#include <glm/mat4x4.hpp>
 
 #include "sprite_renderer.h"
 #include "text_renderer.h"
@@ -15,21 +17,19 @@ namespace twod {
  */
 class RendererManager {
  public:
-  RendererManager(glm::mat4 projection_matrix);
+  explicit RendererManager(glm::mat4 projection_matrix);
 
   std::shared_ptr<SpriteRenderer> getSpriteRenderer() {
-    return this->sprite_renderer;
+    return sprite_renderer_;
   }
 
-  std::shared_ptr<TextRenderer> getTextRenderer() {
-    return this->text_renderer;
-  }
+  std::shared_ptr<TextRenderer> getTextRenderer() { return text_renderer_; }
 
  private:
-  std::shared_ptr<SpriteRenderer> sprite_renderer;
-  std::shared_ptr<TextRenderer> text_renderer;
+  std::shared_ptr<SpriteRenderer> sprite_renderer_;
+  std::shared_ptr<TextRenderer> text_renderer_;
 };
 }  // namespace twod
 }  // namespace common
 
-#endif  // RENDERER_MANAGER_H
+#endif  // COMMON_2D_RENDERER_MANAGER_H_

--- a/src/common/2D/sprite.cpp
+++ b/src/common/2D/sprite.cpp
@@ -3,9 +3,14 @@
 namespace common {
 namespace twod {
 
+Sprite::Sprite(common::resources::Texture texture) : texture_(texture) {}
+Sprite::Sprite(common::resources::Texture texture, glm::vec2 position,
+               glm::vec2 size, glm::vec2 scale)
+    : Object2D(position, size, scale), texture_(texture) {}
+
 void Sprite::render(std::shared_ptr<RendererManager> renderer_manager) {
-  renderer_manager->getSpriteRenderer()->DrawSprite(
-      this->getTexture(), this->getPosition(), this->getSize());
+  renderer_manager->getSpriteRenderer()->DrawSprite(getTexture(), getPosition(),
+                                                    getSize());
 }
 
 }  // namespace twod

--- a/src/common/2D/sprite.h
+++ b/src/common/2D/sprite.h
@@ -1,5 +1,5 @@
-#ifndef SPRITE_H
-#define SPRITE_H
+#ifndef COMMON_2D_SPRITE_H_
+#define COMMON_2D_SPRITE_H_
 
 #include "common/resources/texture.h"
 #include "object2D.h"
@@ -14,24 +14,21 @@ namespace twod {
  */
 class Sprite : public Object2D {
  public:
-  Sprite(common::resources::Texture texture) : texture(texture) {}
+  explicit Sprite(common::resources::Texture texture);
   Sprite(common::resources::Texture texture,
          glm::vec2 position = glm::vec2(0.0f), glm::vec2 size = glm::vec2(0.0f),
-         glm::vec2 scale = glm::vec2(1.0f))
-      : texture(texture), Object2D(position, size, scale) {}
+         glm::vec2 scale = glm::vec2(1.0f));
 
-  void setTexture(common::resources::Texture texture) {
-    this->texture = texture;
-  }
+  void setTexture(common::resources::Texture texture) { texture_ = texture; }
 
-  common::resources::Texture& getTexture() { return this->texture; }
+  const common::resources::Texture& getTexture() const { return texture_; }
 
   void render(std::shared_ptr<RendererManager> renderer_manager);
 
  private:
-  common::resources::Texture texture;
+  common::resources::Texture texture_;
 };
 }  // namespace twod
 }  // namespace common
 
-#endif  // SPRITE_H
+#endif  // COMMON_2D_SPRITE_H_

--- a/src/common/2D/sprite_renderer.cpp
+++ b/src/common/2D/sprite_renderer.cpp
@@ -8,65 +8,65 @@
 namespace common {
 namespace twod {
 
-using common::resources::Shader;
-using common::resources::Texture;
-
-SpriteRenderer::SpriteRenderer(Shader& shader, glm::mat4 projection_matrix)
-    : shader(shader), projection_matrix(projection_matrix) {
-  this->init();
+SpriteRenderer::SpriteRenderer(common::resources::Shader shader,
+                               glm::mat4 projection_matrix)
+    : shader_(shader), projection_matrix_(projection_matrix) {
+  init();
 }
 
-void SpriteRenderer::DrawSprite(Texture& texture, glm::vec2 position,
-                                glm::vec2 size, float rotate, glm::vec4 color) {
+void SpriteRenderer::DrawSprite(const common::resources::Texture& texture,
+                                glm::vec2 position, glm::vec2 size,
+                                float rotate, glm::vec4 color) {
   // prepare transformations
   glm::mat4 model = generateModelMatrix(position, size, rotate);
 
-  this->DrawSprite(texture, model, color);
+  DrawSprite(texture, model, color);
 }
 
-void SpriteRenderer::DrawSprite(Texture& texture, glm::mat4 model_matrix,
-                                glm::vec4 color) {
-  this->shader.activate();
+void SpriteRenderer::DrawSprite(const common::resources::Texture& texture,
+                                glm::mat4 model_matrix, glm::vec4 color) {
+  shader_.activate();
 
-  this->shader.setMat4("model", model_matrix);
-  this->shader.setVec4("spriteColor", color);
+  shader_.setMat4("model", model_matrix);
+  shader_.setVec4("spriteColor", color);
 
-  this->bindTextureAndDraw(texture);
+  bindTextureAndDraw(texture);
 }
 
 // Private functions.
 
 void SpriteRenderer::init() {
   // configure VAO/VBO
-  unsigned int VBO;
+  unsigned int vbo;
   float vertices[] = {
       // pos      // tex
       0.0f, 1.0f, 0.0f, 0.0f, 1.0f, 0.0f, 1.0f, 1.0f, 0.0f, 0.0f, 0.0f, 1.0f,
 
       0.0f, 1.0f, 0.0f, 0.0f, 1.0f, 1.0f, 1.0f, 0.0f, 1.0f, 0.0f, 1.0f, 1.0f};
 
-  glGenVertexArrays(1, &this->VAO);
-  glGenBuffers(1, &VBO);
+  glGenVertexArrays(1, &vao_);
+  glGenBuffers(1, &vbo);
 
-  glBindBuffer(GL_ARRAY_BUFFER, VBO);
+  glBindBuffer(GL_ARRAY_BUFFER, vbo);
   glBufferData(GL_ARRAY_BUFFER, sizeof(vertices), vertices, GL_STATIC_DRAW);
 
-  glBindVertexArray(this->VAO);
+  glBindVertexArray(vao_);
   glEnableVertexAttribArray(0);
   glVertexAttribPointer(0, 4, GL_FLOAT, GL_FALSE, 4 * sizeof(float), (void*)0);
   glBindBuffer(GL_ARRAY_BUFFER, 0);
   glBindVertexArray(0);
 
   // configure shaders
-  this->shader.activate();
-  this->shader.setMat4("projection", this->projection_matrix);
+  shader_.activate();
+  shader_.setMat4("projection", projection_matrix_);
 }
 
-void SpriteRenderer::bindTextureAndDraw(Texture& texture) {
+void SpriteRenderer::bindTextureAndDraw(
+    const common::resources::Texture& texture) {
   glActiveTexture(GL_TEXTURE0);
   texture.bind();
 
-  glBindVertexArray(this->VAO);
+  glBindVertexArray(vao_);
   glDrawArrays(GL_TRIANGLES, 0, 6);
   glBindVertexArray(0);
 }

--- a/src/common/2D/sprite_renderer.h
+++ b/src/common/2D/sprite_renderer.h
@@ -1,5 +1,9 @@
-#ifndef SPRITE_RENDERER_H
-#define SPRITE_RENDERER_H
+#ifndef COMMON_2D_SPRITE_RENDERER_H_
+#define COMMON_2D_SPRITE_RENDERER_H_
+
+#include <glm/mat4x4.hpp>
+#include <glm/vec2.hpp>
+#include <glm/vec4.hpp>
 
 #include "common/resources/shader.h"
 #include "common/resources/texture.h"
@@ -7,35 +11,31 @@
 namespace common {
 namespace twod {
 
-using common::resources::Shader;
-using common::resources::Texture;
-
 class SpriteRenderer {
  public:
-  SpriteRenderer(Shader& shader, glm::mat4 projection_matrix);
+  SpriteRenderer(common::resources::Shader shader, glm::mat4 projection_matrix);
 
-  void DrawSprite(Texture& texture, glm::vec2 position,
-                  glm::vec2 size = glm::vec2(10.0f, 10.0f), float rotate = 0.0f,
-                  glm::vec4 color = glm::vec4(1.0f));
+  void DrawSprite(const common::resources::Texture& texture, glm::vec2 position,
+                  glm::vec2 size, float rotate, glm::vec4 color);
 
-  void DrawSprite(Texture& texture, glm::mat4 model_matrix,
-                  glm::vec4 color = glm::vec4(1.0f));
+  void DrawSprite(const common::resources::Texture& texture,
+                  glm::mat4 model_matrix, glm::vec4 color);
 
  private:
   void init();
 
-  void bindTextureAndDraw(Texture& texture);
+  void bindTextureAndDraw(const common::resources::Texture& texture);
 
   glm::mat4 generateModelMatrix(glm::vec2 position, glm::vec2 size,
                                 float rotate);
 
-  Shader shader;
-  glm::mat4 projection_matrix;
+  common::resources::Shader shader_;
+  glm::mat4 projection_matrix_;
 
-  unsigned int VAO;
+  unsigned int vao_;
 };
 
 }  // namespace twod
 }  // namespace common
 
-#endif  // SPRITE_RENDERER_H
+#endif  // COMMON_2D_SPRITE_RENDERER_H_

--- a/src/common/2D/text_renderer.cpp
+++ b/src/common/2D/text_renderer.cpp
@@ -6,75 +6,73 @@
 #include <sstream>
 #include FT_FREETYPE_H
 
+#include "common/utils/logger.h"
 #include "glm/glm.hpp"
 #include "glm/gtc/matrix_transform.hpp"
 
 namespace common {
 namespace twod {
 
-TextRenderer::TextRenderer(Shader& shader, glm::mat4 projection_matrix)
-    : shader(shader) {
+TextRenderer::TextRenderer(common::resources::Shader shader,
+                           glm::mat4 projection_matrix)
+    : shader_(shader) {
   // Configure shaders
-  this->shader.activate();
-  this->shader.setMat4("projection", projection_matrix);
-  this->init();
+  shader_.activate();
+  shader_.setMat4("projection", projection_matrix);
+  init();
 }
 
-void TextRenderer::RenderText(std::string text, float x, float y, float scale,
-                              glm::vec3 color, float rotate) {
+void TextRenderer::RenderText(const std::string& text, float x, float y,
+                              float scale, glm::vec3 color, float rotate) {
   // activate corresponding render state
-  this->shader.activate();
-  this->shader.setVec3("textColor", color);
+  shader_.activate();
+  shader_.setVec3("textColor", color);
 
   glActiveTexture(GL_TEXTURE0);
-  glBindVertexArray(this->VAO);
+  glBindVertexArray(vao_);
 
   // Set up initial values.
   float rotation_radians = glm::radians(rotate);
   glm::vec2 starting_position = glm::vec2(x, y);
 
   // iterate through all characters
-  std::string::const_iterator c;
-  for (c = text.begin(); c != text.end(); c++) {
-    Character ch = this->characters[*c];
+  for (const char& c : text) {
+    Character ch = characters_[c];
 
-    starting_position = this->renderCharacter(*c, starting_position.x,
-                                              starting_position.y, scale);
+    starting_position =
+        renderCharacter(c, starting_position.x, starting_position.y, scale);
   }
   glBindVertexArray(0);
   glBindTexture(GL_TEXTURE_2D, 0);
 }
 
-void TextRenderer::RenderTextInBoundingBox(std::string text,
-                                           BoundingBox2D bounding_box,
-                                           float scale, glm::vec3 color,
-                                           bool scale_to_fit) {
+void TextRenderer::RenderTextInBoundingBox(
+    const std::string& text, const common::utils::BoundingBox2D& bounding_box,
+    float scale, glm::vec3 color, bool scale_to_fit) {
   float computed_scale =
-      scale_to_fit ? this->computeOptimalScale(text, scale, bounding_box)
-                   : scale;
+      scale_to_fit ? computeOptimalScale(text, scale, bounding_box) : scale;
 
   // activate corresponding render state
-  this->shader.activate();
-  this->shader.setVec3("textColor", color);
+  shader_.activate();
+  shader_.setVec3("textColor", color);
 
   glActiveTexture(GL_TEXTURE0);
-  glBindVertexArray(this->VAO);
+  glBindVertexArray(vao_);
 
   // Set up initial values.
   glm::vec2 starting_position =
       glm::vec2(bounding_box.bottom_left.x,
                 bounding_box.bottom_left.y + bounding_box.size.y -
-                    (this->line_height * computed_scale));
+                    (line_height_ * computed_scale));
 
   // iterate through all characters
-  std::string::const_iterator c;
   std::stringstream potential_word;
   for (char c : text) {
     if (c == '\0') {
       break;
     } else if (c == ' ' || c == '\n') {
       // Render the word, advance the position, and clear the word.
-      glm::vec2 potential_position = this->computeWordFinalPosition(
+      glm::vec2 potential_position = computeWordFinalPosition(
           potential_word.str(), starting_position.x, starting_position.y,
           computed_scale);
 
@@ -82,19 +80,18 @@ void TextRenderer::RenderTextInBoundingBox(std::string text,
       if (potential_position.x >
           (bounding_box.bottom_left.x + bounding_box.size.x)) {
         starting_position.x = bounding_box.bottom_left.x;
-        starting_position.y -= this->line_height * computed_scale;
+        starting_position.y -= line_height_ * computed_scale;
       }
 
-      starting_position =
-          this->renderWord(potential_word.str(), starting_position.x,
-                           starting_position.y, computed_scale);
+      starting_position = renderWord(potential_word.str(), starting_position.x,
+                                     starting_position.y, computed_scale);
 
       starting_position.x +=
-          (this->characters[' '].advance >> 6) * computed_scale;
+          (characters_[' '].advance_ >> 6) * computed_scale;
       potential_word.str("");
 
       if (c == '\n') {
-        starting_position.y -= this->line_height * computed_scale;
+        starting_position.y -= line_height_ * computed_scale;
         starting_position.x = bounding_box.bottom_left.x;
       }
     } else {
@@ -103,7 +100,7 @@ void TextRenderer::RenderTextInBoundingBox(std::string text,
   }
   if (potential_word.str() != "") {
     // Render the word, advance the position, and clear the word.
-    glm::vec2 potential_position = this->computeWordFinalPosition(
+    glm::vec2 potential_position = computeWordFinalPosition(
         potential_word.str(), starting_position.x, starting_position.y,
         computed_scale);
 
@@ -111,13 +108,12 @@ void TextRenderer::RenderTextInBoundingBox(std::string text,
     if (potential_position.x >
         (bounding_box.bottom_left.x + bounding_box.size.x)) {
       starting_position.x = bounding_box.bottom_left.x;
-      starting_position.y -= this->line_height * computed_scale;
+      starting_position.y -= line_height_ * computed_scale;
     }
 
     // Render the word, advance the position, and clear the word.
-    starting_position =
-        this->renderWord(potential_word.str(), starting_position.x,
-                         starting_position.y, computed_scale);
+    starting_position = renderWord(potential_word.str(), starting_position.x,
+                                   starting_position.y, computed_scale);
   }
 
   glBindVertexArray(0);
@@ -127,26 +123,25 @@ void TextRenderer::RenderTextInBoundingBox(std::string text,
 // Private functions
 
 void TextRenderer::init() {
-  this->loadFreeType();
-  this->reserveVaoVbo();
+  loadFreeType();
+  reserveVaoVbo();
 }
 
 void TextRenderer::loadFreeType() {
   FT_Library ft;
   // All functions return a value different than 0 whenever an error occurred
   if (FT_Init_FreeType(&ft)) {
-    std::cout << "ERROR::FREETYPE: Could not init FreeType Library"
-              << std::endl;
+    utils::Logger::Error("FREETYPE: Could not init FreeType Library");
     return;
   }
 
   // load font as face
   FT_Face face;
   // TODO: Change what fonts we read.
-  if (FT_New_Face(ft, "C:/code/cardrogue/assets/fonts/arial.ttf", 0, &face)) {
-    std::cout << "ERROR::FREETYPE: Failed to load font" << std::endl;
+  if (FT_New_Face(ft, "assets/fonts/arial.ttf", 0, &face)) {
+    utils::Logger::Error("FREETYPE: Failed to load font");
   } else {
-    this->line_height = (face->height >> 6);
+    line_height_ = (face->height >> 6);
 
     // set size to load glyphs as
     FT_Set_Pixel_Sizes(face, 0, 48);
@@ -158,7 +153,7 @@ void TextRenderer::loadFreeType() {
     for (unsigned char c = 0; c < 128; c++) {
       // Load character glyph
       if (FT_Load_Char(face, c, FT_LOAD_RENDER)) {
-        std::cout << "ERROR::FREETYTPE: Failed to load Glyph" << std::endl;
+        utils::Logger::Warning("FREETYTPE: Failed to load Glyph");
         continue;
       }
       // generate texture
@@ -179,7 +174,7 @@ void TextRenderer::loadFreeType() {
           glm::ivec2(face->glyph->bitmap.width, face->glyph->bitmap.rows),
           glm::ivec2(face->glyph->bitmap_left, face->glyph->bitmap_top),
           static_cast<unsigned int>(face->glyph->advance.x)};
-      this->characters.insert(std::pair<char, Character>(c, character));
+      characters_.insert(std::pair<char, Character>(c, character));
     }
     glBindTexture(GL_TEXTURE_2D, 0);
   }
@@ -188,10 +183,10 @@ void TextRenderer::loadFreeType() {
 }
 
 void TextRenderer::reserveVaoVbo() {
-  glGenVertexArrays(1, &this->VAO);
-  glGenBuffers(1, &this->VBO);
-  glBindVertexArray(this->VAO);
-  glBindBuffer(GL_ARRAY_BUFFER, this->VBO);
+  glGenVertexArrays(1, &vao_);
+  glGenBuffers(1, &vbo_);
+  glBindVertexArray(vao_);
+  glBindBuffer(GL_ARRAY_BUFFER, vbo_);
   glBufferData(GL_ARRAY_BUFFER, sizeof(float) * 6 * 4, NULL, GL_DYNAMIC_DRAW);
   glEnableVertexAttribArray(0);
   glVertexAttribPointer(0, 4, GL_FLOAT, GL_FALSE, 4 * sizeof(float), 0);
@@ -199,27 +194,27 @@ void TextRenderer::reserveVaoVbo() {
   glBindVertexArray(0);
 }
 
-glm::vec2 TextRenderer::renderWord(std::string word, float x, float y,
+glm::vec2 TextRenderer::renderWord(const std::string& word, float x, float y,
                                    float scale) {
   glm::vec2 starting_position(x, y);
   for (char c2 : word) {
-    Character ch = this->characters[c2];
+    Character ch = characters_[c2];
 
-    starting_position = this->renderCharacter(c2, starting_position.x,
-                                              starting_position.y, scale);
+    starting_position =
+        renderCharacter(c2, starting_position.x, starting_position.y, scale);
   }
   return starting_position;
 }
 
 glm::vec2 TextRenderer::renderCharacter(const char& c, float x, float y,
                                         float scale) {
-  Character ch = this->characters[c];
+  Character ch = characters_[c];
 
-  float xpos = x + ch.bearing.x * scale;
-  float ypos = y - (ch.size.y - ch.bearing.y) * scale;
+  float xpos = x + ch.bearing_.x * scale;
+  float ypos = y - (ch.size_.y - ch.bearing_.y) * scale;
 
-  float w = ch.size.x * scale;
-  float h = ch.size.y * scale;
+  float w = ch.size_.x * scale;
+  float h = ch.size_.y * scale;
 
   float vertices[6][4] = {
       {0.0f, h, 0.0f, 0.0f}, {w, 0.0f, 1.0f, 1.0f}, {0.0f, 0.0f, 0.0f, 1.0f},
@@ -229,12 +224,12 @@ glm::vec2 TextRenderer::renderCharacter(const char& c, float x, float y,
   glm::mat4 model = glm::mat4(1.0f);
   model = glm::translate(model, glm::vec3(xpos, ypos, 0.0f));
 
-  this->shader.setMat4("model", model);
+  shader_.setMat4("model", model);
 
   // render glyph texture over quad
-  glBindTexture(GL_TEXTURE_2D, ch.textureId);
+  glBindTexture(GL_TEXTURE_2D, ch.texture_id_);
   // update content of VBO memory
-  glBindBuffer(GL_ARRAY_BUFFER, this->VBO);
+  glBindBuffer(GL_ARRAY_BUFFER, vbo_);
   glBufferSubData(GL_ARRAY_BUFFER, 0, sizeof(vertices), vertices);
   glBindBuffer(GL_ARRAY_BUFFER, 0);
   // render quad
@@ -242,25 +237,27 @@ glm::vec2 TextRenderer::renderCharacter(const char& c, float x, float y,
 
   // now advance cursors for next glyph (note that advance is number of 1/64
   // pixels)
-  float advance_scaled = (ch.advance >> 6) * scale;
+  float advance_scaled = (ch.advance_ >> 6) * scale;
   return glm::vec2(x + advance_scaled, y);
 }
 
-glm::vec2 TextRenderer::computeWordFinalPosition(std::string word, float x,
-                                                 float y, float scale) {
+glm::vec2 TextRenderer::computeWordFinalPosition(const std::string& word,
+                                                 float x, float y,
+                                                 float scale) {
   glm::vec2 final_position = glm::vec2(x, y);
 
   for (const char& c : word) {
-    Character ch = this->characters[c];
-    float advance_scaled = (ch.advance >> 6) * scale;
+    Character ch = characters_[c];
+    float advance_scaled = (ch.advance_ >> 6) * scale;
     final_position += glm::vec2(advance_scaled, 0.0f);
   }
 
   return final_position;
 }
 
-float TextRenderer::computeOptimalScale(std::string word, float scale,
-                                        BoundingBox2D bounding_box) {
+float TextRenderer::computeOptimalScale(
+    const std::string& word, float scale,
+    const common::utils::BoundingBox2D& bounding_box) {
   float area_of_characters = 0.0f;
   float max_line_width = 0.0f;
   float current_line_width = 0.0f;
@@ -268,10 +265,10 @@ float TextRenderer::computeOptimalScale(std::string word, float scale,
   int num_spaces = 0;
 
   for (char c : word) {
-    Character ch = this->characters[c];
+    Character ch = characters_[c];
     // float w = (ch.advance >> 6) + ch.size.x;
-    float w = (ch.advance >> 6);
-    float h = ch.size.y;
+    float w = (ch.advance_ >> 6);
+    float h = ch.size_.y;
 
     if (c == '\n') {
       max_line_width = max_line_width < current_line_width ? current_line_width
@@ -288,7 +285,7 @@ float TextRenderer::computeOptimalScale(std::string word, float scale,
   }
   max_line_width =
       max_line_width < current_line_width ? current_line_width : max_line_width;
-  int max_number_of_lines = std::ceil(bounding_box.size.y / this->line_height);
+  int max_number_of_lines = std::ceil(bounding_box.size.y / line_height_);
 
   if (scale * max_line_width < bounding_box.size.x) {
     return scale;
@@ -301,7 +298,7 @@ float TextRenderer::computeOptimalScale(std::string word, float scale,
   }
 
   float scale_x = bounding_box.size.x / (max_line_width / num_lines);
-  float scale_y = bounding_box.size.y / (this->line_height * num_lines);
+  float scale_y = bounding_box.size.y / (line_height_ * num_lines);
   return std::min(scale_x, scale_y);
 }
 

--- a/src/common/2D/text_renderer.h
+++ b/src/common/2D/text_renderer.h
@@ -1,9 +1,10 @@
-#ifndef TEXT_RENDERER_H
-#define TEXT_RENDERER_H
+#ifndef COMMON_2D_TEXT_RENDERER_H_
+#define COMMON_2D_TEXT_RENDERER_H_
 
 #include <ft2build.h>
 
 #include <map>
+#include <string>
 #include FT_FREETYPE_H
 
 #include "common/resources/shader.h"
@@ -13,26 +14,26 @@
 namespace common {
 namespace twod {
 
-using common::resources::Shader;
-using common::utils::BoundingBox2D;
-
 class TextRenderer {
  public:
-  TextRenderer(Shader& shader, glm::mat4 projection_matrix);
+  TextRenderer(common::resources::Shader shader, glm::mat4 projection_matrix);
 
   struct Character {
-    unsigned int textureId;  // ID handle of the glyph texture
-    glm::ivec2 size;         // Size of the glyph
-    glm::ivec2 bearing;      // Offset from baseline to left/top of glyph
-    unsigned int advance;    // Offset to advance to next glyph.
+    unsigned int texture_id_;  // ID handle of the glyph texture
+    glm::ivec2 size_;          // Size of the glyph
+    glm::ivec2 bearing_;       // Offset from baseline to left/top of glyph
+    unsigned int advance_;     // Offset to advance to next glyph.
   };
 
-  std::map<char, Character> getCharacters() { return this->characters; }
+  const std::map<char, Character>& getCharacters() const {
+    return characters_;
+  }
 
-  void RenderText(std::string text, float x, float y, float scale,
+  void RenderText(const std::string& text, float x, float y, float scale,
                   glm::vec3 color, float rotate = 0.0f);
 
-  void RenderTextInBoundingBox(std::string text, BoundingBox2D bounding_box,
+  void RenderTextInBoundingBox(const std::string& text,
+                               const common::utils::BoundingBox2D& bounding_box,
                                float scale, glm::vec3 color,
                                bool scale_to_fit = false);
 
@@ -43,34 +44,34 @@ class TextRenderer {
 
   void reserveVaoVbo();
 
-  /*
+  /**
    * Renders a word.
-   * @returns the new position of the cursor
+   * @return the new position of the cursor
    */
-  glm::vec2 renderWord(std::string word, float x, float y, float scale);
+  glm::vec2 renderWord(const std::string& word, float x, float y, float scale);
 
-  /*
+  /**
    * Renders the character at the position.
-   * @returns the new position of the cursor
+   * @return the new position of the cursor
    */
   glm::vec2 renderCharacter(const char& c, float x, float y, float scale);
 
-  glm::vec2 computeWordFinalPosition(std::string word, float x, float y,
+  glm::vec2 computeWordFinalPosition(const std::string& word, float x, float y,
                                      float scale);
 
-  float computeOptimalScale(std::string word, float scale,
-                            BoundingBox2D bounding_box);
+  float computeOptimalScale(const std::string& word, float scale,
+                            const common::utils::BoundingBox2D& bounding_box);
 
-  Shader shader;
+  common::resources::Shader shader_;
 
-  unsigned int VAO, VBO;
+  unsigned int vao_, vbo_;
 
-  std::map<char, Character> characters;
+  std::map<char, Character> characters_;
 
-  float line_height;
+  float line_height_;
 };
 
 }  // namespace twod
 }  // namespace common
 
-#endif  // TEXT_RENDERER
+#endif  // COMMON_2D_TEXT_RENDERER_H_

--- a/src/common/ecs/component.cpp
+++ b/src/common/ecs/component.cpp
@@ -3,7 +3,7 @@
 namespace common {
 namespace ecs {
 
-int Component::next_component_id = 0;
+int Component::kNextComponentId = 0;
 
 }  // namespace ecs
 }  // namespace common

--- a/src/common/ecs/component.h
+++ b/src/common/ecs/component.h
@@ -1,5 +1,5 @@
-#ifndef COMPONENT_H
-#define COMPONENT_H
+#ifndef COMMON_ECS_COMPONENT_H_
+#define COMMON_ECS_COMPONENT_H_
 
 #include <memory>
 
@@ -18,7 +18,7 @@ class Component {
    */
   template <typename T>
   static int getComponentId() {
-    static int component_id = Component::next_component_id++;
+    static int component_id = kNextComponentId++;
     return component_id;
   }
 
@@ -28,10 +28,10 @@ class Component {
   virtual int getComponentIdInstance() const = 0;
 
  private:
-  static int next_component_id;
+  static int kNextComponentId;
 };
 
 }  // namespace ecs
 }  // namespace common
 
-#endif  // COMPONENT_H
+#endif  // COMMON_ECS_COMPONENT_H_

--- a/src/common/resources/resource_manager.h
+++ b/src/common/resources/resource_manager.h
@@ -1,5 +1,5 @@
-#ifndef RESOURCE_MANAGER_H
-#define RESOURCE_MANAGER_H
+#ifndef COMMON_RESOURCES_RESOURCE_MANAGER_H_
+#define COMMON_RESOURCES_RESOURCE_MANAGER_H_
 
 #include <map>
 #include <string>
@@ -12,39 +12,30 @@ namespace resources {
 
 class ResourceManager {
  public:
-  static std::map<std::string, Texture> textures;
-  static std::map<std::string, Shader> shaders;
+  ResourceManager() = delete;
 
-  static Texture LoadTexture(const char* file, std::string texture_name,
-                             bool alpha);
+  static Texture& LoadTexture(const std::string& file,
+                              const std::string& texture_name, bool alpha);
 
-  static Texture LoadTextureRelative(const char* file, std::string texture_name,
-                                     bool alpha);
+  static Shader& LoadShader(const std::string& vertex_shader_file,
+                            const std::string& fragment_shader_file,
+                            const std::string& shader_name);
 
-  static Shader LoadShader(const char* vertexShaderFile,
-                           const char* fragmentShaderFile,
-                           std::string shader_name);
+  static Texture& GetTexture(const std::string& texture_name);
 
-  static Shader LoadShaderRelative(const char* vertexShaderFile,
-                                   const char* fragmentShaderFile,
-                                   std::string shader_name);
-
-  static Texture GetTexture(std::string texture_name);
-
-  static Shader GetShader(std::string shader_name);
-
-  static std::string GetBaseFilePath() { return "C:/code/magetower/"; }
+  static Shader& GetShader(const std::string& shader_name);
 
  private:
-  ResourceManager() {}
+  static Texture loadTextureFromFile(const std::string& file, bool alpha);
 
-  static Texture loadTextureFromFile(const char* file, bool alpha);
+  static Shader loadShaderFromFile(const std::string& vertex_shader,
+                                   const std::string& fragment_shader);
 
-  static Shader loadShaderFromFile(const char* vertexShader,
-                                   const char* fragmentShader);
+  static std::map<std::string, Texture> textures_;
+  static std::map<std::string, Shader> shaders_;
 };
 
 }  // namespace resources
 }  // namespace common
 
-#endif  // RESOURCE_MANAGER_H
+#endif  // COMMON_RESOURCES_RESOURCE_MANAGER_H_

--- a/src/common/resources/shader.cpp
+++ b/src/common/resources/shader.cpp
@@ -1,69 +1,74 @@
 #include "shader.h"
 
-#include <GL/GL.h>
 #include <glad/glad.h>
 
 #include <glm/gtc/type_ptr.hpp>
-#include <iostream>
 #include <string>
+
+#include "common/utils/logger.h"
 
 namespace common {
 namespace resources {
 
-Shader::Shader(const char* vertexData, const char* fragmentData) {
-  GLuint vertexShader = glCreateShader(GL_VERTEX_SHADER);
-  glShaderSource(vertexShader, 1, &(vertexData), 0);
-  glCompileShader(vertexShader);
+Shader::Shader(const char* vertex_data, const char* fragment_data) {
+  GLuint vertex_shader = glCreateShader(GL_VERTEX_SHADER);
+  glShaderSource(vertex_shader, 1, &(vertex_data), 0);
+  glCompileShader(vertex_shader);
 
   // print compile errors if any
   int success;
-  char infoLog[512];
-  glGetShaderiv(vertexShader, GL_COMPILE_STATUS, &success);
+  char info_log[512];
+  glGetShaderiv(vertex_shader, GL_COMPILE_STATUS, &success);
   if (!success) {
-    glGetShaderInfoLog(vertexShader, 512, 0, infoLog);
-    std::cout << "ERROR::SHADER::VERTEX::COMPILATION_FAILED\n"
-              << infoLog << std::endl;
+    glGetShaderInfoLog(vertex_shader, 512, 0, info_log);
+    utils::Logger::Error("SHADER: Vertex compilation failed: " +
+                         std::string(info_log));
   };
 
-  GLuint fragmentShader = glCreateShader(GL_FRAGMENT_SHADER);
-  glShaderSource(fragmentShader, 1, &(fragmentData), 0);
-  glCompileShader(fragmentShader);
+  GLuint fragment_shader = glCreateShader(GL_FRAGMENT_SHADER);
+  glShaderSource(fragment_shader, 1, &(fragment_data), 0);
+  glCompileShader(fragment_shader);
 
-  glGetShaderiv(fragmentShader, GL_COMPILE_STATUS, &success);
+  glGetShaderiv(fragment_shader, GL_COMPILE_STATUS, &success);
   if (!success) {
-    glGetShaderInfoLog(fragmentShader, 512, 0, infoLog);
-    std::cout << "ERROR::SHADER::FRAGMENT::COMPILATION_FAILED\n"
-              << infoLog << std::endl;
+    glGetShaderInfoLog(fragment_shader, 512, 0, info_log);
+    utils::Logger::Error("SHADER: Fragment compilation failed: " +
+                         std::string(info_log));
   };
 
-  this->id = glCreateProgram();
-  glAttachShader(this->id, vertexShader);
-  glAttachShader(this->id, fragmentShader);
-  glLinkProgram(this->id);
+  id_ = glCreateProgram();
+  glAttachShader(id_, vertex_shader);
+  glAttachShader(id_, fragment_shader);
+  glLinkProgram(id_);
 
-  glDeleteShader(vertexShader);
-  glDeleteShader(fragmentShader);
+  glDeleteShader(vertex_shader);
+  glDeleteShader(fragment_shader);
 }
 
-void Shader::activate() { glUseProgram(this->id); }
+void Shader::activate() const { glUseProgram(id_); }
 
-void Shader::setMat4(const std::string& uniformName, const glm::mat4& input) {
-  glUniformMatrix4fv(glGetUniformLocation(this->id, uniformName.c_str()), 1,
-                     false, glm::value_ptr(input));
+void Shader::deactivate() const { glUseProgram(0); }
+
+void Shader::setMat4(const std::string& uniform_name,
+                     const glm::mat4& input) const {
+  glUniformMatrix4fv(glGetUniformLocation(id_, uniform_name.c_str()), 1, false,
+                     glm::value_ptr(input));
 }
 
-void Shader::setVec3(const std::string& uniformName, const glm::vec3 input) {
-  glUniform3f(glGetUniformLocation(this->id, uniformName.c_str()), input.x,
-              input.y, input.z);
+void Shader::setVec3(const std::string& uniform_name,
+                     const glm::vec3& input) const {
+  glUniform3f(glGetUniformLocation(id_, uniform_name.c_str()), input.x, input.y,
+              input.z);
 }
 
-void Shader::setVec4(const std::string& uniformName, const glm::vec4 input) {
-  glUniform4f(glGetUniformLocation(this->id, uniformName.c_str()), input.x,
-              input.y, input.z, input.a);
+void Shader::setVec4(const std::string& uniform_name,
+                     const glm::vec4& input) const {
+  glUniform4f(glGetUniformLocation(id_, uniform_name.c_str()), input.x, input.y,
+              input.z, input.a);
 }
 
-void Shader::setInteger(const std::string& uniformName, const int input) {
-  glUniform1i(glGetUniformLocation(this->id, uniformName.c_str()), input);
+void Shader::setInteger(const std::string& uniform_name, const int input) const {
+  glUniform1i(glGetUniformLocation(id_, uniform_name.c_str()), input);
 }
 
 }  // namespace resources

--- a/src/common/resources/shader.h
+++ b/src/common/resources/shader.h
@@ -1,39 +1,41 @@
-#ifndef SHADER_H
-#define SHADER_H
+#ifndef COMMON_RESOURCES_SHADER_H_
+#define COMMON_RESOURCES_SHADER_H_
+
+#include <string>
 
 #include <glad/glad.h>
-
 #include <glm/mat4x4.hpp>
-#include <string>
+#include <glm/vec3.hpp>
+#include <glm/vec4.hpp>
 
 namespace common {
 namespace resources {
 
 class Shader {
  public:
-  Shader() {}
+  Shader() = default;
 
-  Shader(const char* vertexData, const char* fragmentData);
+  Shader(const char* vertex_data, const char* fragment_data);
 
-  void setMat4(const std::string& uniformName, const glm::mat4& input);
+  void setMat4(const std::string& uniform_name, const glm::mat4& input) const;
 
-  void setVec3(const std::string& uniformName, const glm::vec3 input);
+  void setVec3(const std::string& uniform_name, const glm::vec3& input) const;
 
-  void setVec4(const std::string& uniformName, const glm::vec4 input);
+  void setVec4(const std::string& uniform_name, const glm::vec4& input) const;
 
-  void setInteger(const std::string& uniformName, const int input);
+  void setInteger(const std::string& uniform_name, int input) const;
 
   // Enable the shader
-  void activate();
+  void activate() const;
 
   // Disable the shader
-  void deactivate();
+  void deactivate() const;
 
  private:
-  GLuint id = 0;
+  GLuint id_ = 0;
 };
 
 }  // namespace resources
 }  // namespace common
 
-#endif  // SHADER_H
+#endif  // COMMON_RESOURCES_SHADER_H_

--- a/src/common/resources/texture.cpp
+++ b/src/common/resources/texture.cpp
@@ -6,37 +6,37 @@ namespace common {
 namespace resources {
 
 Texture::Texture()
-    : width(0),
-      height(0),
-      internal_format(GL_RGB),
-      image_format(GL_RGB),
-      wrap_s(GL_REPEAT),
-      wrap_t(GL_REPEAT),
-      filter_min(GL_LINEAR),
-      filter_max(GL_LINEAR) {
-  glGenTextures(1, &this->id);
+    : width_(0),
+      height_(0),
+      internal_format_(GL_RGB),
+      image_format_(GL_RGB),
+      wrap_s_(GL_REPEAT),
+      wrap_t_(GL_REPEAT),
+      filter_min_(GL_LINEAR),
+      filter_max_(GL_LINEAR) {
+  glGenTextures(1, &id_);
 }
 
 void Texture::generate(unsigned int width, unsigned int height,
                        unsigned char* data) {
-  this->width = width;
-  this->height = height;
+  width_ = width;
+  height_ = height;
 
-  glBindTexture(GL_TEXTURE_2D, this->id);
-  glTexImage2D(GL_TEXTURE_2D, 0, this->internal_format, width, height, 0,
-               this->image_format, GL_UNSIGNED_BYTE, data);
+  glBindTexture(GL_TEXTURE_2D, id_);
+  glTexImage2D(GL_TEXTURE_2D, 0, internal_format_, width, height, 0,
+               image_format_, GL_UNSIGNED_BYTE, data);
 
   // set Texture wrap and filter modes
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, this->wrap_s);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, this->wrap_t);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, this->filter_min);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, this->filter_max);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, wrap_s_);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, wrap_t_);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, filter_min_);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, filter_max_);
 
   // unbind texture
   glBindTexture(GL_TEXTURE_2D, 0);
 }
 
-void Texture::bind() const { glBindTexture(GL_TEXTURE_2D, this->id); }
+void Texture::bind() const { glBindTexture(GL_TEXTURE_2D, id_); }
 
 }  // namespace resources
 }  // namespace common

--- a/src/common/resources/texture.h
+++ b/src/common/resources/texture.h
@@ -1,5 +1,5 @@
-#ifndef TEXTURE_H
-#define TEXTURE_H
+#ifndef COMMON_RESOURCES_TEXTURE_H_
+#define COMMON_RESOURCES_TEXTURE_H_
 
 #include "glm/vec2.hpp"
 
@@ -18,27 +18,34 @@ class Texture {
   void bind() const;
 
   void setInternalFormat(unsigned int internal_format) {
-    this->internal_format = internal_format;
+    internal_format_ = internal_format;
   }
 
   void setImageFormat(unsigned int image_format) {
-    this->image_format = image_format;
+    image_format_ = image_format;
   }
 
-  unsigned int getId() { return this->id; }
+  unsigned int getId() const { return id_; }
 
-  unsigned int getWidth() { return this->width; }
+  unsigned int getWidth() const { return width_; }
 
-  unsigned int getHeight() { return this->height; }
+  unsigned int getHeight() const { return height_; }
 
-  glm::vec2 getSizeVector() { return glm::vec2(this->width, this->height); }
+  glm::vec2 getSizeVector() const { return glm::vec2(width_, height_); }
 
  private:
-  unsigned int id, width, height, internal_format, image_format;
-  unsigned int wrap_s, wrap_t, filter_min, filter_max;
+  unsigned int id_;
+  unsigned int width_;
+  unsigned int height_;
+  unsigned int internal_format_;
+  unsigned int image_format_;
+  unsigned int wrap_s_;
+  unsigned int wrap_t_;
+  unsigned int filter_min_;
+  unsigned int filter_max_;
 };
 
 }  // namespace resources
 }  // namespace common
 
-#endif  // TEXTURE_H
+#endif  // COMMON_RESOURCES_TEXTURE_H_

--- a/src/common/scene.h
+++ b/src/common/scene.h
@@ -1,8 +1,9 @@
-#ifndef SCENE_H
-#define SCENE_H
+#ifndef COMMON_SCENE_H_
+#define COMMON_SCENE_H_
 
 #include <glad/glad.h>
 #include <GLFW/glfw3.h>
+#include <glm/vec2.hpp>
 
 #include "common/2D/renderer_manager.h"
 
@@ -14,15 +15,15 @@ namespace common {
  */
 class Scene {
  public:
-  Scene(int id) : id(id), mouse_position(0.0f), next_scene_id(0) {}
+  explicit Scene(int id) : id_(id), mouse_position_(0.0f), next_scene_id_(0) {}
 
-  enum UpdateStatus { OK, CLOSE_WINDOW, SWITCH_SCENE };
+  enum UpdateStatus { kOk, kCloseWindow, kSwitchScene };
 
   virtual void render(
       std::shared_ptr<common::twod::RendererManager> renderer_manager) = 0;
   virtual UpdateStatus update(double delta_time_ms) = 0;
-  virtual void processMouseInput(GLFWwindow* window, double xPos,
-                                 double yPos) = 0;
+  virtual void processMouseInput(GLFWwindow* window, double x_pos,
+                                 double y_pos) = 0;
   virtual void processMouseClick(GLFWwindow* window, int button, int action,
                                  int mods) = 0;
   virtual void processKeyInput(GLFWwindow* window, int key, int scancode,
@@ -30,28 +31,29 @@ class Scene {
   virtual void loadScene() = 0;
   virtual void unloadScene() = 0;
 
-  int getId() { return this->id; }
+  int getId() const { return id_; }
 
-  int getNextSceneId() { return this->next_scene_id; }
+  int getNextSceneId() const { return next_scene_id_; }
 
  protected:
   bool wasLeftButtonClicked(const int button, const int action) {
     return (button == GLFW_MOUSE_BUTTON_LEFT && action == GLFW_PRESS);
   }
 
-  glm::vec2 convertMousePositionIntoScreenCoordinates(double xPos, double yPos,
+  glm::vec2 convertMousePositionIntoScreenCoordinates(double x_pos,
+                                                      double y_pos,
                                                       float screen_width,
                                                       float screen_height) {
-    return glm::vec2(xPos, screen_height - yPos);
+    return glm::vec2(x_pos, screen_height - y_pos);
   }
 
-  glm::vec2 mouse_position;
-  int next_scene_id;
+  glm::vec2 mouse_position_;
+  int next_scene_id_;
 
  private:
-  int id;
+  int id_;
 };
 
 }  // namespace common
 
-#endif  // SCENE_H
+#endif  // COMMON_SCENE_H_

--- a/src/common/scene_manager.cpp
+++ b/src/common/scene_manager.cpp
@@ -1,18 +1,42 @@
 #include "scene_manager.h"
 
+#include "2D/renderer_manager.h"
+
 namespace common {
 
-void SceneManager::update(double deltaTimeMs) {
-  if (this->current_scene != nullptr) {
-    Scene::UpdateStatus status = this->current_scene->update(deltaTimeMs);
+SceneManager::SceneManager(glm::mat4 projection_matrix)
+    : projection_matrix_(projection_matrix),
+      current_scene_(nullptr),
+      should_close_window_(false) {}
+
+void SceneManager::init() {
+  renderer_manager_ =
+      std::make_shared<common::twod::RendererManager>(projection_matrix_);
+}
+
+void SceneManager::addScene(std::shared_ptr<Scene> scene) {
+  scene_map_[scene->getId()] = scene;
+}
+
+void SceneManager::setCurrentScene(int id) {
+  if (current_scene_ != nullptr) {
+    current_scene_->unloadScene();
+  }
+  current_scene_ = scene_map_[id];
+  current_scene_->loadScene();
+}
+
+void SceneManager::update(double delta_time_ms) {
+  if (current_scene_ != nullptr) {
+    Scene::UpdateStatus status = current_scene_->update(delta_time_ms);
 
     switch (status) {
       case Scene::UpdateStatus::CLOSE_WINDOW:
-        this->should_close_window = true;
+        should_close_window_ = true;
         break;
 
       case Scene::UpdateStatus::SWITCH_SCENE:
-        this->setCurrentScene(this->current_scene->getNextSceneId());
+        setCurrentScene(current_scene_->getNextSceneId());
         break;
 
       default:
@@ -22,27 +46,27 @@ void SceneManager::update(double deltaTimeMs) {
   }
 }
 
-void SceneManager::display() {
-  this->current_scene->render(this->renderer_manager);
-}
+void SceneManager::display() { current_scene_->render(renderer_manager_); }
 
 void SceneManager::updateWindow(GLFWwindow* window) {
-  if (this->should_close_window) glfwSetWindowShouldClose(window, true);
+  if (should_close_window_) {
+    glfwSetWindowShouldClose(window, true);
+  }
 }
 
-void SceneManager::processMouseInput(GLFWwindow* window, double xPos,
-                                     double yPos) {
-  this->current_scene->processMouseInput(window, xPos, yPos);
+void SceneManager::processMouseInput(GLFWwindow* window, double x_pos,
+                                     double y_pos) {
+  current_scene_->processMouseInput(window, x_pos, y_pos);
 }
 
 void SceneManager::processMouseClick(GLFWwindow* window, int button, int action,
                                      int mods) {
-  this->current_scene->processMouseClick(window, button, action, mods);
+  current_scene_->processMouseClick(window, button, action, mods);
 }
 
 void SceneManager::processKeyInput(GLFWwindow* window, int key, int scancode,
                                    int action, int mod) {
-  this->current_scene->processKeyInput(window, key, scancode, action, mod);
+  current_scene_->processKeyInput(window, key, scancode, action, mod);
 }
 
 }  // namespace common

--- a/src/common/scene_manager.h
+++ b/src/common/scene_manager.h
@@ -1,15 +1,17 @@
-#ifndef SCENE_MANAGER_H
-#define SCENE_MANAGER_H
+#ifndef COMMON_SCENE_MANAGER_H_
+#define COMMON_SCENE_MANAGER_H_
 
 #include <map>
 #include <memory>
 
+#include <glm/mat4x4.hpp>
+
 #include "scene.h"
 
-namespace common::twod {
 // Forward declaration to avoid including header.
+namespace common::twod {
 class RendererManager;
-}  // namespace common::twod
+}
 
 namespace common {
 
@@ -18,42 +20,27 @@ namespace common {
  */
 class SceneManager {
  public:
-  SceneManager(glm::mat4 projection_matrix)
-      : projection_matrix(projection_matrix), should_close_window(false) {}
+  explicit SceneManager(glm::mat4 projection_matrix);
 
-  void init() {
-    this->renderer_manager =
-        std::make_shared<common::twod::RendererManager>(projection_matrix);
-  }
-
-  void addScene(std::shared_ptr<Scene> scene) {
-    scene_map[scene->getId()] = scene;
-  }
-
-  void setCurrentScene(int id) {
-    if (this->current_scene != nullptr) {
-      this->current_scene->unloadScene();
-    }
-    this->current_scene = scene_map[id];
-    this->current_scene->loadScene();
-  }
-
-  void update(double deltaTimeMs);
+  void init();
+  void addScene(std::shared_ptr<Scene> scene);
+  void setCurrentScene(int id);
+  void update(double delta_time_ms);
   void display();
   void updateWindow(GLFWwindow* window);
-  void processMouseInput(GLFWwindow* window, double xPos, double yPos);
+  void processMouseInput(GLFWwindow* window, double x_pos, double y_pos);
   void processMouseClick(GLFWwindow* window, int button, int action, int mods);
   void processKeyInput(GLFWwindow* window, int key, int scancode, int action,
                        int mod);
 
  private:
-  glm::mat4 projection_matrix;
-  std::map<int, std::shared_ptr<Scene>> scene_map;
-  std::shared_ptr<Scene> current_scene;
-  bool should_close_window;
+  glm::mat4 projection_matrix_;
+  std::map<int, std::shared_ptr<Scene>> scene_map_;
+  std::shared_ptr<Scene> current_scene_;
+  bool should_close_window_;
 
-  std::shared_ptr<common::twod::RendererManager> renderer_manager;
+  std::shared_ptr<common::twod::RendererManager> renderer_manager_;
 };
 }  // namespace common
 
-#endif  // SCENE_MANAGER_H
+#endif  // COMMON_SCENE_MANAGER_H_

--- a/src/common/utils/logger.cpp
+++ b/src/common/utils/logger.cpp
@@ -5,22 +5,34 @@
 namespace common {
 namespace utils {
 
+void Logger::Init() {}
+
 void Logger::Log(LogLevel level, const std::string& message) {
   switch (level) {
-    case LogLevel::INFO:
+    case LogLevel::kInfo:
       std::cout << "INFO: ";
       break;
 
-    case LogLevel::WARNING:
-      std::cout << "WARNING: ";
+    case LogLevel::kWarning:
+      std::clog << "WARNING: ";
       break;
 
-    case LogLevel::ERROR:
-      std::cout << "ERROR: ";
+    case LogLevel::kError:
+      std::cerr << "ERROR: ";
       break;
   }
 
   std::cout << message << "\n";
+}
+
+void Logger::Info(const std::string& message) { Log(LogLevel::kInfo, message); }
+
+void Logger::Warning(const std::string& message) {
+  Log(LogLevel::kWarning, message);
+}
+
+void Logger::Error(const std::string& message) {
+  Log(LogLevel::kError, message);
 }
 
 }  // namespace utils

--- a/src/common/utils/logger.h
+++ b/src/common/utils/logger.h
@@ -1,30 +1,24 @@
-#ifndef LOGGER_H
-#define LOGGER_H
+#ifndef COMMON_UTILS_LOGGER_H_
+#define COMMON_UTILS_LOGGER_H_
 
 #include <string>
 
 namespace common {
 namespace utils {
 
-enum class LogLevel { INFO, WARNING, ERROR };
+enum class LogLevel { kInfo, kWarning, kError };
 
 class Logger {
  public:
-  static void Init() {}
+  Logger() = delete;
 
+  static void Init();
   static void Log(LogLevel level, const std::string& message);
-
-  static void Info(const std::string& message) { Log(LogLevel::INFO, message); }
-
-  static void Warning(const std::string& message) {
-    Log(LogLevel::WARNING, message);
-  }
-
-  static void Error(const std::string& message) {
-    Log(LogLevel::ERROR, message);
-  }
+  static void Info(const std::string& message);
+  static void Warning(const std::string& message);
+  static void Error(const std::string& message);
 };
 }  // namespace utils
 }  // namespace common
 
-#endif  // LOGGER_H
+#endif  // COMMON_UTILS_LOGGER_H_

--- a/src/common/window.h
+++ b/src/common/window.h
@@ -1,11 +1,11 @@
-#ifndef WINDOW_H
-#define WINDOW_H
+#ifndef COMMON_WINDOW_H_
+#define COMMON_WINDOW_H_
+
+#include <string>
 
 #include <glad/glad.h>
 #include <GLFW/glfw3.h>
-
 #include <glm/gtc/matrix_transform.hpp>
-#include <iostream>
 
 #include "2D/renderer_manager.h"
 #include "scene_manager.h"
@@ -14,12 +14,7 @@ namespace common {
 
 class Window {
  public:
-  Window(unsigned int width, unsigned int height, const char* name)
-      : width(width), height(height), name(name), last_frame_ms(0.0f) {
-    this->scene_manager = std::make_shared<SceneManager>(
-        glm::ortho(0.0f, static_cast<float>(width), 0.0f,
-                   static_cast<float>(height), -1.0f, 1.0f));
-  }
+  Window(unsigned int width, unsigned int height, const std::string& name);
 
   static void mouseMovementCallback(GLFWwindow* window, double xPos,
                                     double yPos);
@@ -30,26 +25,27 @@ class Window {
   static void keyCallback(GLFWwindow* window, int key, int scancode, int action,
                           int mod);
 
+  static void framebufferSizeCallback(GLFWwindow* window, int width,
+                                      int height);
+
   int init();
 
   void start();
 
-  std::shared_ptr<SceneManager> getSceneManager() {
-    return this->scene_manager;
-  }
+  std::shared_ptr<SceneManager> getSceneManager() { return scene_manager; }
 
  private:
   void initCallbacks();
 
-  unsigned int width;
-  unsigned int height;
-  const char* name;
+  unsigned int width_;
+  unsigned int height_;
+  std::string name_;
 
-  GLFWwindow* window_internal;
+  GLFWwindow* window_internal_;
   std::shared_ptr<SceneManager> scene_manager;
 
-  double last_frame_ms;
+  double last_frame_ms_;
 };
 }  // namespace common
 
-#endif  // WINDOW_H
+#endif  // COMMON_WINDOW_H_

--- a/src/core/components/texture_component.h
+++ b/src/core/components/texture_component.h
@@ -1,5 +1,5 @@
-#ifndef TEXTURE_COMPONENT_H
-#define TEXTURE_COMPONENT_H
+#ifndef CORE_COMPONENTS_TEXTURE_COMPONENT_H_
+#define CORE_COMPONENTS_TEXTURE_COMPONENT_H_
 
 #include <memory>
 #include <string>
@@ -13,29 +13,30 @@ namespace components {
 
 class TextureComponent : public common::ecs::Component {
  public:
-  TextureComponent(std::string image_name, std::string image_path,
-                   bool alpha = false) {
-    this->texture = common::resources::ResourceManager::LoadTextureRelative(
-        image_path.c_str(), image_name, /*alpha=*/alpha);
+  TextureComponent(const std::string& image_name,
+                   const std::string& image_path, bool alpha = false) {
+    texture_ = common::resources::ResourceManager::LoadTexture(
+        image_path, image_name, /*alpha=*/alpha);
   }
 
-  TextureComponent(common::resources::Texture texture) : texture(texture) {}
+  explicit TextureComponent(common::resources::Texture texture)
+      : texture_(texture) {}
 
   std::unique_ptr<Component> clone() const override {
-    return std::make_unique<TextureComponent>(texture);
+    return std::make_unique<TextureComponent>(texture_);
   }
 
   int getComponentIdInstance() const override {
     return Component::getComponentId<TextureComponent>();
   }
 
-  common::resources::Texture& getTexture() { return this->texture; }
+  common::resources::Texture& getTexture() { return texture_; }
 
  private:
-  common::resources::Texture texture;
+  common::resources::Texture texture_;
 };
 
 }  // namespace components
 }  // namespace core
 
-#endif  // TEXTURE_COMPONENT_H
+#endif  // CORE_COMPONENTS_TEXTURE_COMPONENT_H_

--- a/src/core/renderutils/card_render_util.h
+++ b/src/core/renderutils/card_render_util.h
@@ -1,5 +1,5 @@
-#ifndef CARD_RENDER_UTIL_H
-#define CARD_RENDER_UTIL_H
+#ifndef CORE_RENDERUTILS_CARD_RENDER_UTIL_H_
+#define CORE_RENDERUTILS_CARD_RENDER_UTIL_H_
 
 #include <memory>
 
@@ -28,12 +28,12 @@ class CardRenderUtil {
       std::shared_ptr<common::twod::RendererManager> renderer_manager);
 
  private:
-  common::resources::Texture card_back_texture;
-  common::resources::Texture creature_card_frame_texture;
-  common::resources::Texture spell_card_frame_texture;
+  common::resources::Texture* card_back_texture_;
+  common::resources::Texture* creature_card_frame_texture_;
+  common::resources::Texture* spell_card_frame_texture_;
 };
 
 }  // namespace renderutils
 }  // namespace core
 
-#endif  // CARD_RENDER_UTIL_H
+#endif  // CORE_RENDERUTILS_CARD_RENDER_UTIL_H_

--- a/src/core/renderutils/card_render_utils.cpp
+++ b/src/core/renderutils/card_render_utils.cpp
@@ -1,4 +1,5 @@
 #include "card_render_util.h"
+
 #include "common/resources/resource_manager.h"
 #include "common/resources/texture.h"
 #include "core/components/card_component.h"
@@ -10,71 +11,68 @@
 namespace core {
 namespace renderutils {
 
-using common::ecs::Entity;
-using common::resources::Texture;
-using common::twod::RendererManager;
-using core::components::CardComponent;
-using core::components::IsHoveredTagComponent;
-using core::components::PositionComponent;
-using core::components::SizeComponent;
-
+namespace {
 // Note these are represented as 'percentages' from the origin of the image (so
 // that size of the image doesn't matter).
-const static glm::vec2 ART_POSITION_FACTOR = glm::vec2(
+const glm::vec2 kArtPositionFactor = glm::vec2(
     16.0f / core::CARD_DEFAULT_WIDTH, 124.0f / core::CARD_DEFAULT_HEIGHT);
-const static glm::vec2 ART_SIZE_FACTOR = glm::vec2(
+const glm::vec2 kArtSizeFactor = glm::vec2(
     166.0f / core::CARD_DEFAULT_WIDTH, 85.0f / core::CARD_DEFAULT_HEIGHT);
 
-const static glm::vec2 NAME_POSITION_FACTOR = glm::vec2(
+const glm::vec2 kNamePositionFactor = glm::vec2(
     16.0f / core::CARD_DEFAULT_WIDTH, 221.0f / core::CARD_DEFAULT_HEIGHT);
-const static glm::vec2 NAME_SIZE_FACTOR = glm::vec2(
+const glm::vec2 kNameSizeFactor = glm::vec2(
     166.0f / core::CARD_DEFAULT_WIDTH, 19.0f / core::CARD_DEFAULT_HEIGHT);
+}  // namespace
 
 CardRenderUtil::CardRenderUtil() {
-  this->card_back_texture =
-      common::resources::ResourceManager::LoadTextureRelative(
-          "assets/cards/card_back.png", "card_back_texture", /*alpha=*/true);
-  this->creature_card_frame_texture =
-      common::resources::ResourceManager::LoadTextureRelative(
+  card_back_texture_ = &common::resources::ResourceManager::LoadTexture(
+      "assets/cards/card_back.png", "card_back_texture", /*alpha=*/true);
+  creature_card_frame_texture_ =
+      &common::resources::ResourceManager::LoadTexture(
           "assets/cards/creature_frame.png", "creature_frame_texture",
           /*alpha=*/true);
-  this->spell_card_frame_texture =
-      common::resources::ResourceManager::LoadTextureRelative(
-          "assets/cards/non_creature_frame.png", "non_creature_frame_texture",
-          /*alpha=*/true);
+  spell_card_frame_texture_ = &common::resources::ResourceManager::LoadTexture(
+      "assets/cards/non_creature_frame.png", "non_creature_frame_texture",
+      /*alpha=*/true);
 }
 
 void CardRenderUtil::renderCard(
-    const Entity& entity, std::shared_ptr<RendererManager> renderer_manager) {
+    const common::ecs::Entity& entity,
+    std::shared_ptr<common::twod::RendererManager> renderer_manager) {
   // If the entity isn't a card then return early.
-  if (!entity.hasComponent<CardComponent>()) {
+  if (!entity.hasComponent<components::CardComponent>()) {
     return;
   }
 
-  CardComponent card = *entity.getComponent<CardComponent>();
+  components::CardComponent& card =
+      *entity.getComponent<components::CardComponent>();
   if (!card.isVisible()) {
     return;
   }
 
   // Get the card, position, and size components.
-  PositionComponent position = *entity.getComponent<PositionComponent>();
-  SizeComponent size = *entity.getComponent<SizeComponent>();
+  components::PositionComponent& position =
+      *entity.getComponent<components::PositionComponent>();
+  components::SizeComponent& size =
+      *entity.getComponent<components::SizeComponent>();
   glm::vec2 resolved_position = position.getPosition();
 
-  Texture& texture = card.isFaceup() ? this->creature_card_frame_texture
-                                     : this->card_back_texture;
-  renderer_manager->getSpriteRenderer()->DrawSprite(texture, resolved_position,
-                                                    size.getSizeVec());
+  common::resources::Texture& texture = card.isFaceup()
+                                            ? *creature_card_frame_texture_
+                                            : *card_back_texture_;
+  renderer_manager->getSpriteRenderer()->DrawSprite(
+      texture, resolved_position, size.getSizeVec(), 0.0f, glm::vec4(1.0f));
 
   if (card.isFaceup()) {
     renderer_manager->getSpriteRenderer()->DrawSprite(
         card.getCardArtTexture(),
-        resolved_position + (size.getSizeVec() * ART_POSITION_FACTOR),
-        size.getSizeVec() * ART_SIZE_FACTOR);
+        resolved_position + (size.getSizeVec() * kArtPositionFactor),
+        size.getSizeVec() * kArtSizeFactor, 0.0f, glm::vec4(1.0f));
     renderer_manager->getTextRenderer()->RenderTextInBoundingBox(
         card.getName(),
-        {resolved_position + (size.getSizeVec() * NAME_POSITION_FACTOR),
-         size.getSizeVec() * NAME_SIZE_FACTOR},
+        {resolved_position + (size.getSizeVec() * kNamePositionFactor),
+         size.getSizeVec() * kNameSizeFactor},
         /*scale=*/16.0f, core::COLOR_BLACK,
         /*scale_to_fit=*/true);
   }
@@ -83,8 +81,8 @@ void CardRenderUtil::renderCard(
 void CardRenderUtil::renderCardBack(
     glm::vec2 position, glm::vec2 size,
     std::shared_ptr<common::twod::RendererManager> renderer_manager) {
-  renderer_manager->getSpriteRenderer()->DrawSprite(this->card_back_texture,
-                                                    position, size);
+  renderer_manager->getSpriteRenderer()->DrawSprite(
+      *card_back_texture_, position, size, 0.0f, glm::vec4(1.0f));
 }
 
 }  // namespace renderutils

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include <glad/glad.h>
 #include <GLFW/glfw3.h>
 
@@ -7,41 +9,22 @@
 #include "scenes/battle/battle_scene.h"
 #include "scenes/mainmenu/main_menu_scene.h"
 
-void framebuffer_size_callback(GLFWwindow* window, int width, int height);
-void callback();
-
-using common::Window;
-using scenes::battle::BattleScene;
-using scenes::mainmenu::MainMenuScene;
-
 int main() {
   common::utils::Logger::Init();
-  Window* window =
-      new Window(core::SCREEN_WIDTH, core::SCREEN_HEIGHT, "Mage Tower");
+  auto window = std::make_unique<common::Window>(
+      core::SCREEN_WIDTH, core::SCREEN_HEIGHT, std::string("Mage Tower"));
   window->init();
 
   // Load the scenes for the game.
   auto scene_manager = window->getSceneManager();
 
-  std::shared_ptr<MainMenuScene> main_menu_scene =
-      std::make_shared<MainMenuScene>();
+  auto main_menu_scene = std::make_shared<scenes::mainmenu::MainMenuScene>();
   scene_manager->addScene(main_menu_scene);
   scene_manager->setCurrentScene(core::MAIN_MENU_SCENE_ID);
 
-  std::shared_ptr<BattleScene> battle_scene = std::make_shared<BattleScene>();
+  auto battle_scene = std::make_shared<scenes::battle::BattleScene>();
   scene_manager->addScene(battle_scene);
 
   window->start();
   return 0;
-}
-
-void callback() {}
-
-// glfw: whenever the window size changed (by OS or user resize) this callback
-// function executes
-// ---------------------------------------------------------------------------------------------
-void framebuffer_size_callback(GLFWwindow* window, int width, int height) {
-  // make sure the viewport matches the new window dimensions; note that width
-  // and height will be significantly larger than specified on retina displays.
-  glViewport(0, 0, width, height);
 }

--- a/src/scenes/battle/rendersystems/ui_render_system.cpp
+++ b/src/scenes/battle/rendersystems/ui_render_system.cpp
@@ -15,50 +15,46 @@ namespace scenes {
 namespace battle {
 namespace rendersystems {
 
-using common::ecs::Engine;
-using common::resources::Texture;
-using common::twod::RendererManager;
-using scenes::battle::components::EnemyTagComponent;
-using scenes::battle::components::ManaComponent;
-using scenes::battle::components::PlayerTagComponent;
-
-const glm::vec2 UiRenderSystem::MANA_SIZE = glm::vec2(50.0f);
-const glm::vec2 UiRenderSystem::PLAYER_MANA_POSITION = glm::vec2(24.0f);
-const glm::vec2 UiRenderSystem::ENEMY_MANA_POSITION =
-    glm::vec2(core::SCREEN_WIDTH - MANA_SIZE.x - 24.0f,
-              core::SCREEN_HEIGHT - MANA_SIZE.y - 24.0f);
+const glm::vec2 UiRenderSystem::kManaSize = glm::vec2(50.0f);
+const glm::vec2 UiRenderSystem::kPlayerManaPosition = glm::vec2(24.0f);
+const glm::vec2 UiRenderSystem::kEnemyManaPosition =
+    glm::vec2(core::SCREEN_WIDTH - kManaSize.x - 24.0f,
+              core::SCREEN_HEIGHT - kManaSize.y - 24.0f);
 
 UiRenderSystem::UiRenderSystem() {
-  this->mana_texture = common::resources::ResourceManager::LoadTextureRelative(
+  mana_texture_ = &common::resources::ResourceManager::LoadTexture(
       "assets/battle/ui/mana_texture.png", "mana_texture", /*alpha=*/true);
 }
 
-void UiRenderSystem::render(Engine& engine,
-                            std::shared_ptr<RendererManager> renderer_manager) {
+void UiRenderSystem::render(
+    common::ecs::Engine& engine,
+    std::shared_ptr<common::twod::RendererManager> renderer_manager) {
   for (auto& entity : engine.getEntities()) {
     // If it is the player, render the mana of the player.
-    if (entity->hasComponent<PlayerTagComponent>()) {
+    if (entity->hasComponent<components::PlayerTagComponent>()) {
       // Get the mana component of the player entity.
-      auto player_mana_component = entity->getComponent<ManaComponent>();
+      auto player_mana_component =
+          entity->getComponent<components::ManaComponent>();
 
-      glm::vec2 position = PLAYER_MANA_POSITION;
+      glm::vec2 position = kPlayerManaPosition;
       for (int i = 0; i < player_mana_component->getMaxMana(); i++) {
-        renderer_manager->getSpriteRenderer()->DrawSprite(this->mana_texture,
-                                                          position, MANA_SIZE);
-        position.x += MANA_SIZE.x;
+        renderer_manager->getSpriteRenderer()->DrawSprite(
+            *mana_texture_, position, kManaSize, 0.0f, glm::vec4(1.0f));
+        position.x += kManaSize.x;
       }
     }
 
     // If it is the enemy, render the mana of the enemy.
-    if (entity->hasComponent<EnemyTagComponent>()) {
+    if (entity->hasComponent<components::EnemyTagComponent>()) {
       // Get the mana component of the enemy entity.
-      auto enemy_mana_component = entity->getComponent<ManaComponent>();
+      auto enemy_mana_component =
+          entity->getComponent<components::ManaComponent>();
 
-      glm::vec2 position = ENEMY_MANA_POSITION;
+      glm::vec2 position = kEnemyManaPosition;
       for (int i = 0; i < enemy_mana_component->getMaxMana(); i++) {
-        renderer_manager->getSpriteRenderer()->DrawSprite(this->mana_texture,
-                                                          position, MANA_SIZE);
-        position.x -= MANA_SIZE.x;
+        renderer_manager->getSpriteRenderer()->DrawSprite(
+            *mana_texture_, position, kManaSize, 0.0f, glm::vec4(1.0f));
+        position.x -= kManaSize.x;
       }
     }
   }

--- a/src/scenes/battle/rendersystems/ui_render_system.h
+++ b/src/scenes/battle/rendersystems/ui_render_system.h
@@ -1,5 +1,5 @@
-#ifndef UI_RENDER_SYSTEM_H
-#define UI_RENDER_SYSTEM_H
+#ifndef SCENES_BATTLE_RENDERSYSTEMS_UI_RENDER_SYSTEM_H_
+#define SCENES_BATTLE_RENDERSYSTEMS_UI_RENDER_SYSTEM_H_
 
 #include <memory>
 
@@ -23,14 +23,14 @@ class UiRenderSystem : public common::ecs::RenderSystem {
               std::shared_ptr<common::twod::RendererManager> renderer_manager);
 
  private:
-  const static glm::vec2 PLAYER_MANA_POSITION;
-  const static glm::vec2 ENEMY_MANA_POSITION;
-  const static glm::vec2 MANA_SIZE;
+  static const glm::vec2 kPlayerManaPosition;
+  static const glm::vec2 kEnemyManaPosition;
+  static const glm::vec2 kManaSize;
 
-  common::resources::Texture mana_texture;
+  common::resources::Texture* mana_texture_;
 };
 }  // namespace rendersystems
 }  // namespace battle
 }  // namespace scenes
 
-#endif  // UI_RENDER_SYSTEM_H
+#endif  // SCENES_BATTLE_RENDERSYSTEMS_UI_RENDER_SYSTEM_H_

--- a/src/scenes/mainmenu/main_menu_scene.cpp
+++ b/src/scenes/mainmenu/main_menu_scene.cpp
@@ -8,53 +8,52 @@
 namespace scenes {
 namespace mainmenu {
 
-using common::resources::ResourceManager;
-using common::resources::Texture;
-using common::twod::Sprite;
-
 void MainMenuScene::render(
     std::shared_ptr<common::twod::RendererManager> renderer_manager) {
   auto sprite_renderer = renderer_manager->getSpriteRenderer();
   // Render the background.
-  sprite_renderer->DrawSprite(this->background_texture, glm::vec2(0.0f, 0.0f),
-                              this->background_texture.getSizeVector());
+  sprite_renderer->DrawSprite(*background_texture_, glm::vec2(0.0f, 0.0f),
+                              background_texture_->getSizeVector(), 0.0f,
+                              glm::vec4(1.0f));
 
   // Render the buttons.
-  start_button->render(renderer_manager);
-  exit_button->render(renderer_manager);
+  start_button_->render(renderer_manager);
+  exit_button_->render(renderer_manager);
 }
 
 void MainMenuScene::processMouseClick(GLFWwindow* window, int button,
                                       int action, int mods) {
   // If clicked, check interaction with our buttons on the screen.
-  if (this->wasLeftButtonClicked(button, action)) {
-    if (this->start_button->containsPoint(this->mouse_position)) {
+  if (wasLeftButtonClicked(button, action)) {
+    if (start_button_->containsPoint(mouse_position_)) {
       // Switch scene
-      this->update_status = UpdateStatus::SWITCH_SCENE;
-      this->next_scene_id = static_cast<int>(core::SceneId::Battle);
-    } else if (this->exit_button->containsPoint(this->mouse_position)) {
-      this->update_status = UpdateStatus::CLOSE_WINDOW;
+      update_status_ = UpdateStatus::kSwitchScene;
+      next_scene_id_ = static_cast<int>(core::SceneId::Battle);
+    } else if (exit_button_->containsPoint(mouse_position_)) {
+      update_status_ = UpdateStatus::kCloseWindow;
     }
   }
 }
 
 void MainMenuScene::loadScene() {
-  this->background_texture = ResourceManager::LoadTextureRelative(
+  background_texture_ = &common::resources::ResourceManager::LoadTexture(
       "assets/mainmenu/background.png", "main_menu_background", /*alpha=*/true);
 
-  Texture start_button_texture = ResourceManager::LoadTextureRelative(
-      "assets/mainmenu/start_game_button.png", "start_game_button",
-      /*alpha=*/true);
-  this->start_button = std::make_shared<Sprite>(
+  common::resources::Texture& start_button_texture =
+      common::resources::ResourceManager::LoadTexture(
+          "assets/mainmenu/start_game_button.png", "start_game_button",
+          /*alpha=*/true);
+  start_button_ = std::make_shared<common::twod::Sprite>(
       start_button_texture,
       glm::vec2(core::HALF_SCREEN_WIDTH - (start_button_texture.getWidth() / 2),
                 core::HALF_SCREEN_HEIGHT),
       start_button_texture.getSizeVector());
 
-  Texture exit_button_texture = ResourceManager::LoadTextureRelative(
-      "assets/mainmenu/exit_game_button.png", "exit_game_button",
-      /*alpha=*/true);
-  this->exit_button = std::make_shared<Sprite>(
+  common::resources::Texture& exit_button_texture =
+      common::resources::ResourceManager::LoadTexture(
+          "assets/mainmenu/exit_game_button.png", "exit_game_button",
+          /*alpha=*/true);
+  exit_button_ = std::make_shared<common::twod::Sprite>(
       exit_button_texture,
       glm::vec2(core::HALF_SCREEN_WIDTH - (exit_button_texture.getWidth() / 2),
                 core::HALF_SCREEN_HEIGHT - exit_button_texture.getHeight()),

--- a/src/scenes/mainmenu/main_menu_scene.h
+++ b/src/scenes/mainmenu/main_menu_scene.h
@@ -1,11 +1,10 @@
-#ifndef MAIN_MENU_SCENE_H
-#define MAIN_MENU_SCENE_H
+#ifndef SCENES_MAINMENU_MAIN_MENU_SCENE_H_
+#define SCENES_MAINMENU_MAIN_MENU_SCENE_H_
 
-#include "common/2D/renderer_manager.h"
+#include <memory>
+
 #include "common/2D/sprite.h"
-#include "common/resources/texture.h"
 #include "common/scene.h"
-#include "core/consts.h"
 #include "core/scene_ids.h"
 
 namespace scenes {
@@ -14,36 +13,31 @@ namespace mainmenu {
 class MainMenuScene : public common::Scene {
  public:
   MainMenuScene()
-      : Scene(static_cast<int>(core::SceneId::MainMenu)),
-        update_status(UpdateStatus::OK) {}
+      : common::Scene(core::MAIN_MENU_SCENE_ID),
+        update_status_(UpdateStatus::kOk) {}
 
-  void render(std::shared_ptr<common::twod::RendererManager> renderer_manager);
-
-  UpdateStatus update(double delta_time_ms) { return this->update_status; }
-
-  void processMouseInput(GLFWwindow* window, double xPos, double yPos) {
-    this->mouse_position = this->convertMousePositionIntoScreenCoordinates(
-        xPos, yPos, core::SCREEN_WIDTH, core::SCREEN_HEIGHT);
+  void render(
+      std::shared_ptr<common::twod::RendererManager> renderer_manager) override;
+  void processMouseInput(GLFWwindow* window, double x_pos,
+                         double y_pos) override {
+    mouse_position_ = convertMousePositionIntoScreenCoordinates(
+        x_pos, y_pos, core::SCREEN_WIDTH, core::SCREEN_HEIGHT);
   }
-
-  void processMouseClick(GLFWwindow* window, int button, int action, int mods);
-
+  void processMouseClick(GLFWwindow* window, int button, int action,
+                         int mods) override;
   void processKeyInput(GLFWwindow* window, int key, int scancode, int action,
-                       int mod) {}
-
-  void loadScene();
-
-  void unloadScene() {}
+                       int mod) override {}
+  UpdateStatus update(double delta_time_ms) override { return update_status_; };
+  void loadScene() override;
+  void unloadScene() override {}
 
  private:
-  common::resources::Texture background_texture;
-
-  std::shared_ptr<common::twod::Sprite> start_button;
-  std::shared_ptr<common::twod::Sprite> exit_button;
-
-  UpdateStatus update_status;
+  UpdateStatus update_status_;
+  common::resources::Texture* background_texture_;
+  std::shared_ptr<common::twod::Sprite> start_button_;
+  std::shared_ptr<common::twod::Sprite> exit_button_;
 };
 }  // namespace mainmenu
 }  // namespace scenes
 
-#endif  // MAIN_MENU_SCENE_H
+#endif  // SCENES_MAINMENU_MAIN_MENU_SCENE_H_


### PR DESCRIPTION
This commit applies a wide range of changes to the codebase to bring it into compliance with Google's C++ Style Guide. The changes include:

- Fixing a memory leak in main.cpp by using std::unique_ptr.
- Enforcing consistent naming conventions for member variables, enums, etc.
- Correcting header guards to be more specific.
- Removing unnecessary `this->` usage.
- Organizing includes.
- Using the provided Logger instead of std::cout.
- Moving function definitions from headers to source files.
- Improving const correctness.
- Using pointers instead of copies for textures where appropriate to avoid unnecessary copying.
- Removing hardcoded file paths to improve portability.